### PR TITLE
Instantiate RoundRobin Class for message testing 

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -3,6 +3,19 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
+    "node_modules/@acuminous/bitsyntax": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "debug": "^4.3.4",
+        "safe-buffer": "~5.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/@reactflow/background": {
       "version": "11.3.6",
       "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.6.tgz",
@@ -326,6 +339,20 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
       "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ=="
     },
+    "node_modules/amqplib": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+      "integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+      "dependencies": {
+        "@acuminous/bitsyntax": "^0.1.2",
+        "buffer-more-ints": "~1.0.0",
+        "readable-stream": "1.x >=1.1.9",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -360,6 +387,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -391,6 +423,11 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.4.tgz",
       "integrity": "sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -488,6 +525,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -532,6 +585,11 @@
       "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
       "dev": true
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -574,6 +632,11 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -591,6 +654,11 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -612,6 +680,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -655,6 +728,17 @@
         "react-dom": ">=17"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -666,6 +750,16 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/sass": {
       "version": "1.69.5",
@@ -702,6 +796,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -712,6 +811,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,24 @@
   "packages": {
     "": {
       "dependencies": {
+        "amqplib": "^0.10.3",
         "reactflow": "^11.10.1"
       },
       "devDependencies": {
         "sass": "^1.69.5"
+      }
+    },
+    "node_modules/@acuminous/bitsyntax": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "debug": "^4.3.4",
+        "safe-buffer": "~5.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/@reactflow/background": {
@@ -334,6 +348,20 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
       "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ=="
     },
+    "node_modules/amqplib": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+      "integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+      "dependencies": {
+        "@acuminous/bitsyntax": "^0.1.2",
+        "buffer-more-ints": "~1.0.0",
+        "readable-stream": "1.x >=1.1.9",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -368,6 +396,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -399,6 +432,11 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.4.tgz",
       "integrity": "sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -496,6 +534,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -540,6 +594,11 @@
       "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
       "dev": true
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -582,6 +641,11 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -599,6 +663,11 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -620,6 +689,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -663,6 +737,17 @@
         "react-dom": ">=17"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -674,6 +759,16 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/sass": {
       "version": "1.69.5",
@@ -710,6 +805,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -720,6 +820,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "amqplib": "^0.10.3",
     "reactflow": "^11.10.1"
   },
   "devDependencies": {

--- a/stress-testing/round-robin.js
+++ b/stress-testing/round-robin.js
@@ -4,7 +4,7 @@ The test is a Class that has the following methods: turnOnConsumer, prepTests, r
 
 To create a new instance of the RoundRobin class, you will need to provide the following: rabbitAddress, exchanges, bindings
   * rabbitAddress is the URL or URL in which the test can connect to the user's RabbitMQ's enviornmnet.
-  * exhanges is an array containing objects with information on the exchanges
+  * exchanges is an array containing objects with information on the exchanges
   * bindings is an array containing objects with the information on all of the bindings 
 
 examples: 
@@ -154,7 +154,7 @@ class roundRobinTest {
     if (this.readyToTest === false) return;
   }
 
-  //this will take a snapshot of the current testing enviornment 
+  //this will take a snapshot of the current testing environment 
   takeSnapShot () {
     this.snapShots.push({
       rabbitAddress: this.rabbitAddress,
@@ -165,7 +165,7 @@ class roundRobinTest {
     });
   } 
 
-  //this method will allow you to completely update your Round Robin test enviornment 
+  //this method will allow you to completely update your Round Robin test environment 
   updateRoundRobinSuite (rabbitAddress, exchanges, bindings) {
     this.rabbitAddress = rabbitAddress;
     this.exchanges = {}

--- a/stress-testing/round-robin.js
+++ b/stress-testing/round-robin.js
@@ -1,0 +1,191 @@
+/* 
+This test will act as a publisher itself, and connect to the host to send messages to all exchanges, queues, and consumers. 
+The test is a Class that has the following methods: turnOnConsumer, prepTests, runTest, stopTest, takeSnapShot, and updateRoundRobinSuite
+
+To create a new instance of the RoundRobin class, you will need to provide the following: rabbitAddress, exchanges, bindings
+  * rabbitAddress is the URL or URL in which the test can connect to the user's RabbitMQ's enviornmnet.
+  * exhanges is an array containing objects with information on the exchanges
+  * bindings is an array containing objects with the information on all of the bindings 
+
+examples: 
+  rabbitAddress = 'amqp://localhost'
+  exchanges = [{ 
+      name: 'trekker_topic',
+      vhost: '/',
+      type: 'topic',
+      durable: true,
+      auto_delete: false,
+      internal: false,
+      arguments: {}
+    }, {...}, {...}]
+  bindings = [{
+      source: 'trekker_topic',
+      vhost: '/',
+      destination: 'AuthQueue',
+      destination_type: 'queue',
+      routing_key: 'Auth',
+      arguments: {}
+    }, {...}, {...}]
+*/ 
+
+const amqp = require('amqplib/callback_api');
+
+//this test consumer is currently connecting but is not showing the messages in the console of this test
+const testConsume = (exchangeName) => {
+  const exchange = exchangeName;
+  amqp.connect('amqp://localhost', function (error, connection) {
+    console.log('consumer is on')
+    if (error) console.log('error connecting to amqp: ', error.message);
+    connection.createChannel(function (error, channel) {
+  
+      if (error) console.log('error connecting to the channel: ',error.message)
+      channel.assertExchange(exchange, 'topic', {durable: true})
+      
+      channel.assertQueue('TestQueue');
+      channel.bindQueue('TestQueue', exchange, '*');
+      channel.consume(
+        'TestQueue',
+        async (msg) => {
+          const message = await JSON.parse(msg.toString());
+          console.log(msg);
+        },
+      { noAck: true })
+    })
+  })
+};
+
+//this is the test publisher that will send out all of the messages during the test
+const testPublisher = (exchangeName, exchangeType, rabbitAddress, key, msgObj) => {
+  console.log('connecting to the publisher')
+
+  amqp.connect(rabbitAddress, function (error, connection) {
+
+    if (error) console.log('error connecting to amqp: ', error.message);
+
+    connection.createChannel(function (err, channel) {
+
+    if (error) console.log('error connecting to the channel: ', err.message);
+      channel.assertExchange(exchangeName, exchangeType, {durable: true})
+      channel.publish(exchangeName, key, Buffer.from(JSON.stringify(msgObj)))
+      //console.log(key, msgObj)
+      })
+      setTimeout(() => {
+        connection.close();
+      }, 500)
+    })
+};
+
+//these are only used to test the RoundRobin Class
+const exchanges = [
+    { 
+      name: 'trekker_topic',
+      vhost: '/',
+      type: 'topic',
+      durable: true,
+      auto_delete: false,
+      internal: false,
+      arguments: {}
+    }]
+const bindings1 = [
+  {
+    source: 'trekker_topic',
+    vhost: '/',
+    destination: 'AuthQueue',
+    destination_type: 'queue',
+    routing_key: 'Auth',
+    arguments: {}
+  },
+  {
+    source: 'trekker_topic',
+    vhost: '/',
+    destination: 'AppQueue',
+    destination_type: 'queue',
+    routing_key: '#.failed',
+    arguments: {}
+  }]
+
+
+class roundRobinTest {
+  constructor (rabbitAddress, exchanges, bindings) {
+    this.rabbitAddress = rabbitAddress;
+    this.exchanges = {}
+    this.bindings = bindings;
+    this.readyToTest = false;
+    this.testMessages = [];
+    this.totalMessagesSent = 0;
+    this.snapShots = [];
+    this.message = {
+      type: 'Round Robin',
+    };
+    exchanges.forEach((exc) => {
+      this.exchanges[exc.name] = exc;
+    })
+  }
+  //this will be removed later, it's only been added for testing purposes. 
+  turnOnConsumer () {
+    testConsume('trekker_topic');
+  }
+  //this method needs to be run so it can compile all of the exchanges and bindings in a format to be easily sent to the publisher 
+  prepTests () { 
+    this.turnOnConsumer();
+    this.bindings.forEach((binding) => {
+      this.testMessages.push({
+        exchangeName: binding.source,
+        exchangeType: this.exchanges[binding.source].type,
+        rabbitAddress: this.rabbitAddress,
+        key: binding.routing_key,
+        message: this.message,
+      })
+    })
+    this.readyToTest = true; 
+  }
+
+  //method to begin testing
+  runTest () { 
+    if (this.readyToTest === false) return;
+    this.testMessages.forEach((msg) => {
+      testPublisher(msg.exchangeName, msg.exchangeType, msg.rabbitAddress, msg.key, msg.message)
+      this.totalMessagesSent++;
+    })
+  }
+
+  //method to stop running the test 
+  stopTest () {
+    if (this.readyToTest === false) return;
+  }
+
+  //this will take a snapshot of the current testing enviornment 
+  takeSnapShot () {
+    this.snapShots.push({
+      rabbitAddress: this.rabbitAddress,
+      exchanges: this.exchanges,
+      bindings: this.bindings,
+      testMessages: this.testMessages,
+      totalMessagesSent: this.totalMessagesSent,
+    });
+  } 
+
+  //this method will allow you to completely update your Round Robin test enviornment 
+  updateRoundRobinSuite (rabbitAddress, exchanges, bindings) {
+    this.rabbitAddress = rabbitAddress;
+    this.exchanges = {}
+    this.bindings = bindings;
+    this.readyToTest = false;
+    this.testMessages = [];
+    this.totalMessagesSent = 0;
+    this.message = {
+      type: 'Round Robin',
+    };
+    exchanges.forEach((exc) => {
+      this.exchanges[exc.name] = exc;
+    })
+  }
+}
+
+const tester = new roundRobinTest('amqp://localhost', exchanges, bindings1)
+tester.prepTests()
+tester.runTest();
+tester.takeSnapShot()
+
+
+//export default roundRobinTest;

--- a/stress-testing/testconsumer.js
+++ b/stress-testing/testconsumer.js
@@ -1,0 +1,28 @@
+const amqp = require('amqplib/callback_api');
+
+const testConsume = (exchangeName) => {
+  const exchange = exchangeName;
+  amqp.connect('amqp://localhost', function (error, connection) {
+    
+    if (error) console.log('error connecting to amqp: ', error.message);
+    connection.createChannel(function (error, channel) {
+  
+      if (error) console.log('error connecting to the channel: ',error.message)
+      channel.assertExchange(exchange, 'topic', {durable: true})
+      
+      channel.assertQueue('TestQueue');
+      channel.bindQueue('TestQueue', exchange, '*');
+      channel.consume(
+        'TestQueue',
+        async (msg) => {
+          const message = await JSON.parse(msg.toString());
+          console.log(message);
+        },
+      { noAck: true })
+    })
+  })
+};
+  
+testConsume('trekker_topic');
+
+module.exports = testConsume;


### PR DESCRIPTION
This test will act as a publisher itself, and connect to the host to send messages to all exchanges, queues, and consumers. 
The test is a Class that has the following methods: turnOnConsumer, prepTests, runTest, stopTest, takeSnapShot, and updateRoundRobinSuite
To create a new instance of the RoundRobin class, you will need to provide the following: rabbitAddress, exchanges, bindings
  * rabbitAddress is the URL or URL in which the test can connect to the user's RabbitMQ's environment.
  * exchanges is an array containing objects with information on the exchanges
  * bindings is an array containing objects with the information on all of the bindings 